### PR TITLE
set log to deploy

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,7 +2,6 @@ import Config
 
 config :recognizer, RecognizerWeb.Endpoint,
   check_origin: false,
-  force_ssl: [hstl: true],
   http: [:inet6, port: 8080],
   server: true
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -8,7 +8,7 @@ recognizer_config =
 config :recognizer, RecognizerWeb.Endpoint,
   url: [
     host: System.get_env("DOMAIN"),
-    port: "PORT" |> System.get_env("80") |> String.to_integer()
+    port: "PORT" |> System.get_env("443") |> String.to_integer()
   ],
   secret_key_base: recognizer_config["SECRET_KEY_BASE"]
 


### PR DESCRIPTION
force_ssl causes a redirect to 443 because it can't see the ssl stuff behind the load balancer
port to 443 so everything gets https urls when phoenix generates urls
log level to info so we can trace things