### PR TITLE
make ssl oauth in production optional

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,5 +18,3 @@ config :phoenix, :logger, false
 config :appsignal, :config, active: true
 
 config :ex_aws, enabled: true
-
-config :recognizer, ExOauth2Provider, force_ssl_in_redirect_uri: true

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -31,6 +31,9 @@ config :appsignal, :config,
   push_api_key: recognizer_config["APPSIGNAL_KEY"],
   env: recognizer_config["APPSIGNAL_ENV"]
 
+config :recognizer, ExOauth2Provider,
+  force_ssl_in_redirect_uri: Map.get(recognizer_config, "FORCE_SSL_OAUTH_APPLICATIONS", true)
+
 config :recognizer, Recognizer.Guardian, secret_key: recognizer_config["GUARDIAN_KEY"]
 
 config :ueberauth, Ueberauth.Strategy.Github.OAuth,


### PR DESCRIPTION
This could be a problem if we allowed third parties to make applications, but considering it's just us right now, this shouldn't cause any problems.