### PR TITLE
Make caching faster for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,14 @@ jobs:
           mix local.hex --force
 
       - name: Cache
-        id: cache
         uses: actions/cache@v2
+        id: cache
         with:
-          key: elixir-${{ hashFiles('Dockerfile', 'mix.lock') }}
+          key: elixir-${{ hashFiles('Dockerfile', 'mix.lock') }}-${{ github.ref }}-test
+          restore-keys: |
+            elixir-${{ hashFiles('Dockerfile', 'mix.lock') }}-${{ github.ref }}-
+            elixir-${{ hashFiles('Dockerfile', 'mix.lock') }}-
+            elixir-
           path: |
             _build
             deps
@@ -104,10 +108,14 @@ jobs:
           mix local.hex --force
 
       - name: Cache
-        id: cache
         uses: actions/cache@v2
+        id: cache
         with:
-          key: elixir-${{ hashFiles('Dockerfile', 'mix.lock') }}
+          key: elixir-${{ hashFiles('Dockerfile', 'mix.lock') }}-${{ github.ref }}-credo
+          restore-keys: |
+            elixir-${{ hashFiles('Dockerfile', 'mix.lock') }}-${{ github.ref }}-
+            elixir-${{ hashFiles('Dockerfile', 'mix.lock') }}-
+            elixir-
           path: |
             _build
             deps


### PR DESCRIPTION
This caches the `_build` and `deps` folder. This should make things a lot faster because it doesn't need to recompile dependencies. It also upgrades cache to v2.

The cache key is based on the a hash of the `mix.lock` file, the hash of `Dockerfile` (in case elixir version changes), and the git reference. So if anything changes with the dependencies, it should skip cache and rebuild everything.