### PR TITLE
trace more third party services and grpc endpoints

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -95,5 +95,6 @@ config :spandex_ecto, SpandexEcto.EctoLogger,
   tracer: Recognizer.Tracer
 
 config :spandex_phoenix, tracer: Recognizer.Tracer
+config :spandex, :decorators, tracer: Recognizer.Tracer
 
 import_config "#{Mix.env()}.exs"

--- a/lib/recognizer/notifications/account.ex
+++ b/lib/recognizer/notifications/account.ex
@@ -5,6 +5,8 @@ defmodule Recognizer.Notifications.Account do
   notification microservice to deliver.
   """
 
+  use Spandex.Decorators
+
   alias Bottle.Account.V1, as: Account
 
   # credo:disable-for-next-line
@@ -71,6 +73,7 @@ defmodule Recognizer.Notifications.Account do
     |> Keyword.get(message_type)
   end
 
+  @decorate span(service: :bullhorn, type: :function)
   defp send_message(resource, atom) when @enabled do
     encoded_message = encode_message(resource, atom)
 

--- a/lib/recognizer/server.ex
+++ b/lib/recognizer/server.ex
@@ -4,10 +4,12 @@ defmodule Recognizer.Server do
   """
 
   use GRPC.Server, service: Bottle.Account.V1.Service
+  use Spandex.Decorators
 
   alias Bottle.Account.V1.NotificationMethodResponse
   alias Recognizer.Accounts
 
+  @decorate trace(name: "gRPC Bottle.Account.V1.NotificationMethod")
   def notification_method(%{event_type: event_type, user: req_user} = request, _stream) do
     Bottle.RequestId.read(:rpc, request)
 

--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,7 @@ defmodule Recognizer.MixProject do
       {:cowboy, "~> 2.8", override: true},
       {:cowlib, "~> 2.9.1", override: true},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
+      {:decorator, "~> 1.2"},
       {:ecto_enum, "~> 1.4"},
       {:ecto_sql, "~> 3.4"},
       {:eqrcode, "~> 0.1.7"},


### PR DESCRIPTION
Adds a span for bullhorn, allowing us to see requests per minute and processing problems easier.

Adds a trace for gRPC. It's very basic, but it will at least let us see performance