### PR TITLE
fix postcss removing error classes

### DIFF
--- a/assets/postcss.config.js
+++ b/assets/postcss.config.js
@@ -8,7 +8,8 @@ module.exports = (options) => {
     plugins: [
       ...(devMode ? [] : [purgecss({
         content: [
-          path.resolve(__dirname, '../lib/recognizer_web/templates/**/*.html.eex')
+          path.resolve(__dirname, '../lib/recognizer_web/templates/**/*.html.eex'),
+          path.resolve(__dirname, '../lib/recognizer_web/views/**/*.ex')
         ]
       })])
     ]


### PR DESCRIPTION
postcss purges unused html classes from the templates folder. This adds the views folder too because that's where the error helper classes are.