### PR TITLE
fix user roles loading

### DIFF
--- a/lib/recognizer/accounts.ex
+++ b/lib/recognizer/accounts.ex
@@ -25,7 +25,13 @@ defmodule Recognizer.Accounts do
 
   """
   def get_user_by_email(email) when is_binary(email) do
-    Repo.get_by(User, email: email)
+    query =
+      from u in User,
+        join: n in assoc(u, :notification_preference),
+        where: u.email == ^email,
+        preload: [notification_preference: n, roles: []]
+
+    Repo.one(query)
   end
 
   @doc """
@@ -45,9 +51,8 @@ defmodule Recognizer.Accounts do
       from o in OAuth,
         join: u in assoc(o, :user),
         join: n in assoc(u, :notification_preference),
-        join: r in assoc(u, :roles),
         where: o.service == ^service and o.service_guid == ^service_guid,
-        preload: [user: {u, [notification_preference: n, roles: r]}]
+        preload: [user: {u, [notification_preference: n, roles: []]}]
 
     with %OAuth{user: user} <- Repo.one(query),
          %User{two_factor_enabled: false} <- user do
@@ -89,9 +94,8 @@ defmodule Recognizer.Accounts do
     query =
       from u in User,
         join: n in assoc(u, :notification_preference),
-        join: r in assoc(u, :roles),
         where: u.email == ^email,
-        preload: [notification_preference: n, roles: r]
+        preload: [notification_preference: n, roles: []]
 
     with %User{} = user <- Repo.one(query),
          true <- User.valid_password?(user, password),
@@ -124,9 +128,8 @@ defmodule Recognizer.Accounts do
     query =
       from u in User,
         join: n in assoc(u, :notification_preference),
-        join: r in assoc(u, :roles),
         where: u.id == ^id,
-        preload: [notification_preference: n, roles: r]
+        preload: [notification_preference: n, roles: []]
 
     Repo.one!(query)
   end

--- a/lib/recognizer_web/views/accounts/api/user_settings_view.ex
+++ b/lib/recognizer_web/views/accounts/api/user_settings_view.ex
@@ -31,7 +31,7 @@ defmodule RecognizerWeb.Accounts.Api.UserSettingsView do
         type: user.type,
         company_name: user.company_name,
         newsletter: user.newsletter,
-        admin: Role.admin?(user),
+        staff: Role.admin?(user),
         notification_preferences: render("notification_preferences.json", user)
       }
     }


### PR DESCRIPTION
Roles is a one to many relationship, so it can't be preloaded the way I was doing it previously. 

I also changed the view from `admin` to `staff`. The role is named `admin`, but every staff has it (due to how bad the Joshua permissions are). We also have a `super-admin` role which is more akin to an `admin` role. I know we will probably be ditching this once we figure out how we want to redo permissions.