### PR TITLE
Fix the 2FA update flow

### DIFF
--- a/lib/recognizer_web/controllers/accounts/api/user_settings_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/api/user_settings_controller.ex
@@ -55,6 +55,14 @@ defmodule RecognizerWeb.Accounts.Api.UserSettingsController do
     end
   end
 
+  def update(conn, %{"action" => "update_two_factor", "user" => %{"two_factor_enabled" => false}}) do
+    user = Authentication.fetch_current_user(conn)
+
+    with {:ok, updated_user} <- Accounts.update_user_two_factor(user, %{"two_factor_enabled" => false}) do
+      render(conn, "show.json", user: updated_user)
+    end
+  end
+
   def update(conn, %{"action" => "update_two_factor", "user" => user_params}) do
     user = Authentication.fetch_current_user(conn)
     preference = get_in(user_params, ["notification_preference", "two_factor"])

--- a/lib/recognizer_web/views/accounts/api/user_settings_view.ex
+++ b/lib/recognizer_web/views/accounts/api/user_settings_view.ex
@@ -18,10 +18,10 @@ defmodule RecognizerWeb.Accounts.Api.UserSettingsView do
     }
   end
 
-  def render("confirm_two_factor.json", %{settings: %{notification_preference: preference} = settings}) do
+  def render("confirm_two_factor.json", %{settings: %{notification_preference: %{two_factor: method}} = settings}) do
     %{
       two_factor: %{
-        method: preference,
+        method: method,
         recovery_codes: recovery_codes(settings)
       }
     }

--- a/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
@@ -67,7 +67,17 @@ defmodule RecognizerWeb.Api.UserSettingsControllerTest do
           "user" => %{"notification_preference" => %{"two_factor" => "text"}}
         })
 
-      assert %{"two_factor" => %{"recovery_codes" => _}} = json_response(conn, 202)
+      assert %{"two_factor" => %{"method" => "text", "recovery_codes" => _}} = json_response(conn, 202)
+    end
+
+    test "returns the user with `update_two_factor` action and `two_factor_enabled` is false", %{conn: conn} do
+      conn =
+        put(conn, "/api/settings", %{
+          "action" => "update_two_factor",
+          "user" => %{"two_factor_enabled" => false}
+        })
+
+      assert %{"user" => %{"two_factor_enabled" => false}} = json_response(conn, 200)
     end
   end
 


### PR DESCRIPTION
During testing I found a couple little issues that needed fixing:

1. When disabling 2FA we should just return the user rather than going through the confirmation flow (and caching values we'll ignore).
2. We were using a string to look up the preference for the view but it's an atom