### PR TITLE
enable 2fa when saved data from redis

### DIFF
--- a/lib/recognizer/accounts.ex
+++ b/lib/recognizer/accounts.ex
@@ -456,7 +456,8 @@ defmodule Recognizer.Accounts do
     attrs = %{
       notification_preference: %{two_factor: preference},
       recovery_codes: generate_new_recovery_codes(user),
-      two_factor_seed: new_seed
+      two_factor_seed: new_seed,
+      two_factor_enabled: true
     }
 
     Redix.noreply_command(:redix, ["SET", "two_factor_settings:#{user.id}", Jason.encode!(attrs)])


### PR DESCRIPTION
Not sure if you want it here or when we load the data, but we should set it enabled when you eventually confirm