### PR TITLE
Add message type to config

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -33,7 +33,8 @@ config :recognizer,
      ]},
     {Bottle.Account.V1.TwoFactorRequested, recognizer_config["NOTIFICATION_SERVICE_SQS_URL"]},
     {Bottle.Account.V1.PasswordChanged, recognizer_config["NOTIFICATION_SERVICE_SQS_URL"]},
-    {Bottle.Account.V1.PasswordReset, recognizer_config["NOTIFICATION_SERVICE_SQS_URL"]}
+    {Bottle.Account.V1.PasswordReset, recognizer_config["NOTIFICATION_SERVICE_SQS_URL"]},
+    {Bottle.Account.V1.TwoFactorRecoveryCodeUsed, recognizer_config["NOTIFICATION_SERVICE_SQS_URL"]}
   ],
   two_factor_issuer: recognizer_config["TWO_FACTOR_ISSUER"],
   redis_host: recognizer_config["REDIS_HOST"]


### PR DESCRIPTION
When this auth is behind us we definitely need to start looking into moving to SNS or Rabbit. This type of configuration is definitely error prone.