### PR TITLE
fix error response status code for API endpoints

### DIFF
--- a/lib/recognizer_web/controllers/accounts/api/user_settings_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/api/user_settings_controller.ex
@@ -13,6 +13,7 @@ defmodule RecognizerWeb.Accounts.Api.UserSettingsController do
 
       {:error, changeset} ->
         conn
+        |> put_status(:bad_request)
         |> put_view(ErrorView)
         |> render("error.json", changeset: changeset)
     end
@@ -31,6 +32,7 @@ defmodule RecognizerWeb.Accounts.Api.UserSettingsController do
 
       {:error, changeset} ->
         conn
+        |> put_status(:bad_request)
         |> put_view(ErrorView)
         |> render("error.json", changeset: changeset)
     end


### PR DESCRIPTION
because 200 doesn't indicate form errors