### PR TITLE
update mailchimp base_url to use correct domain

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,7 +9,7 @@ config :recognizer, RecognizerWeb.Endpoint,
 
 config :recognizer,
   mailchimp: [
-    base_url: "https://server.api.mailchimp.com"
+    base_url: "https://us10.api.mailchimp.com"
   ]
 
 config :logger,


### PR DESCRIPTION
Turns out that the domain was wrong. Thanks mailchimp API docs :( 