### PR TITLE
allow unsubscribed emails to pass without failure

### DIFF
--- a/lib/recognizer/mailchimp.ex
+++ b/lib/recognizer/mailchimp.ex
@@ -23,6 +23,7 @@ defmodule Recognizer.Mailchimp do
 
     case HTTPoison.put!(complete_url, body, %{"Content-type" => "application/json"}, hackney: hackney) do
       %{status: 200} -> {:ok, user}
+      %{body: %{"status" => "unsubscribed"}} -> {:ok, user}
       %{body: %{"detail" => reason}} -> {:error, reason}
       err -> {:error, inspect(err)}
     end


### PR DESCRIPTION
We are getting errors from emails already on the list but unsubscribed. We should allow this and not fail. 