### PR TITLE
allow nil names from github

### DIFF
--- a/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
@@ -92,7 +92,7 @@ defmodule RecognizerWeb.Accounts.UserOAuthController do
 
   defp split_name(nil), do: ["", ""]
   defp split_name(name) do
-    [first_name, rest] = String.split(info.name, " ", size: 2)
+    [first_name, rest] = String.split(name, " ", size: 2)
     last_name = if rest == [], do: "", else: hd(rest)
     [first_name, last_name]
   end

--- a/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
@@ -81,13 +81,19 @@ defmodule RecognizerWeb.Accounts.UserOAuthController do
   # they use `name` which is the full name.
   # We need to make a best guess at dividing it into first and last.
   defp provider_params(%{provider: :github, info: info}) do
-    [first_name | rest] = String.split(info.name, " ", size: 2)
-    last_name = if rest == [], do: "", else: hd(rest)
+    [first_name | last_name] = split_name(info.name)
 
     %{
       email: info.email,
       first_name: first_name,
       last_name: last_name
     }
+  end
+
+  defp split_name(nil), do: ["", ""]
+  defp split_name(name) do
+    [first_name, rest] = String.split(info.name, " ", size: 2)
+    last_name = if rest == [], do: "", else: hd(rest)
+    [first_name, last_name]
   end
 end

--- a/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
@@ -91,6 +91,7 @@ defmodule RecognizerWeb.Accounts.UserOAuthController do
   end
 
   defp split_name(nil), do: ["", ""]
+
   defp split_name(name) do
     [first_name, rest] = String.split(name, " ", size: 2)
     last_name = if rest == [], do: "", else: hd(rest)


### PR DESCRIPTION
I'm pretty sure GitHub allows nil names, which is why this can be returned from oauth. Support this by just setting both fields to blank strings.