### PR TITLE
Correct match on name fragments

### DIFF
--- a/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
@@ -93,8 +93,8 @@ defmodule RecognizerWeb.Accounts.UserOAuthController do
   defp split_name(nil), do: ["", ""]
 
   defp split_name(name) do
-    [first_name, rest] = String.split(name, " ", size: 2)
-    last_name = if rest == [], do: "", else: hd(rest)
-    [first_name, last_name]
+    with [first_name] <- String.split(name, " ", parts: 2) do
+      [first_name, ""]
+    end
   end
 end


### PR DESCRIPTION
Names can include more than 2 parts.

https://appsignal.com/system76/sites/5fd06bc40264440f385e25e0/exceptions/incidents/39?timestamp=2021-02-11T19%3A58%3A02Z