### PR TITLE
add a more helpful token expired page

### DIFF
--- a/lib/recognizer_web/controllers/fallback_controller.ex
+++ b/lib/recognizer_web/controllers/fallback_controller.ex
@@ -5,8 +5,6 @@ defmodule RecognizerWeb.FallbackController do
 
   @behaviour Guardian.Plug.ErrorHandler
 
-  plug :fetch_session
-
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {:already_authenticated, _reason}, _) do
     conn

--- a/lib/recognizer_web/controllers/fallback_controller.ex
+++ b/lib/recognizer_web/controllers/fallback_controller.ex
@@ -19,14 +19,14 @@ defmodule RecognizerWeb.FallbackController do
 
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {:invalid_token, _reason}, _) do
-    if not json?(conn) do
+    if json?(conn) do
+      respond(conn, :unauthorized, "401")
+    else
       conn
       |> Recognizer.Guardian.Plug.sign_out()
       |> fetch_session()
       |> clear_session()
       |> call({:error, :unauthenticated})
-    else
-      respond(conn, :unauthorized, "401")
     end
   end
 

--- a/lib/recognizer_web/controllers/fallback_controller.ex
+++ b/lib/recognizer_web/controllers/fallback_controller.ex
@@ -19,15 +19,19 @@ defmodule RecognizerWeb.FallbackController do
 
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {:invalid_token, _reason}, _) do
-    conn
-    |> Recognizer.Guardian.Plug.sign_out()
-    |> fetch_session()
-    |> clear_session()
-    |> respond(:unauthorized, "401-invalid")
+    if not json?(conn) do
+      conn
+      |> Recognizer.Guardian.Plug.sign_out()
+      |> fetch_session()
+      |> clear_session()
+      |> call({:error, :unauthenticated})
+    else
+      respond(conn, :unauthorized, "401")
+    end
   end
 
   @impl Guardian.Plug.ErrorHandler
-  def auth_error(conn, {type, reason}, _) do
+  def auth_error(conn, {_type, _reason}, _) do
     respond(conn, :unauthorized, "401")
   end
 

--- a/lib/recognizer_web/templates/error/401-invalid.html.eex
+++ b/lib/recognizer_web/templates/error/401-invalid.html.eex
@@ -2,6 +2,6 @@
   <h2 class="title is-2 mb-5 has-text-centered-mobile">Login Expired</h2>
 
   <p>
-    Your current login has expired. Please <a href="javascript:history.back()">go back</a> and log in again.
+    Your current login has expired. Please go back and log in again.
   </p>
 </div>

--- a/lib/recognizer_web/templates/error/401-invalid.html.eex
+++ b/lib/recognizer_web/templates/error/401-invalid.html.eex
@@ -1,7 +1,0 @@
-<div class="box">
-  <h2 class="title is-2 mb-5 has-text-centered-mobile">Login Expired</h2>
-
-  <p>
-    Your current login has expired. Please go back and log in again.
-  </p>
-</div>

--- a/lib/recognizer_web/templates/error/401-invalid.html.eex
+++ b/lib/recognizer_web/templates/error/401-invalid.html.eex
@@ -1,0 +1,7 @@
+<div class="box">
+  <h2 class="title is-2 mb-5 has-text-centered-mobile">Login Expired</h2>
+
+  <p>
+    Your current login has expired. Please <a href="javascript:history.back()">go back</a> and log in again.
+  </p>
+</div>


### PR DESCRIPTION
For the redirect loop, if you try using an expired token, you'll get this page instead of the unauthorized page. It will also clear any session data (log you off), so you can log in again and generate a new token instead of re-using an expired session token for login.

TL:DR / better explained:
This avoids the login redirect loop with an expired session token stored