### PR TITLE
Correct what is returned in the transaction

### DIFF
--- a/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
@@ -65,7 +65,7 @@ defmodule RecognizerWeb.Accounts.UserOAuthController do
     Repo.transaction(fn ->
       with {:ok, user} <- Accounts.register_oauth_user(user_params),
            {:ok, _oauth} <- Accounts.create_oauth(user, provider, uid) do
-        {:ok, user}
+        user
       else
         {:error, changeset} ->
           Repo.rollback(changeset)


### PR DESCRIPTION
The Ecto transaction will wrap the result in {:ok, result} when there
isn't a rollback