### PR TITLE
add user_id to logger metadata

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,7 +26,7 @@ config :recognizer, RecognizerWeb.Endpoint,
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id, :trace_id, :span_id]
+  metadata: [:request_id, :user_id, :trace_id, :span_id]
 
 config :grpc, start_server: true
 

--- a/lib/recognizer_web/plugs/auth_plug.ex
+++ b/lib/recognizer_web/plugs/auth_plug.ex
@@ -3,6 +3,8 @@ defmodule RecognizerWeb.AuthPlug do
   `Guardian.Plug.Pipeline` for verifying JWT tokens in the session and header.
   """
 
+  require Logger
+
   use Guardian.Plug.Pipeline,
     otp_app: :recognizer,
     module: Recognizer.Guardian,
@@ -11,4 +13,14 @@ defmodule RecognizerWeb.AuthPlug do
   plug Guardian.Plug.VerifySession, claims: %{"iss" => "system76", "typ" => "access"}
   plug Guardian.Plug.VerifyHeader, claims: %{"iss" => "system76", "typ" => "access"}
   plug Guardian.Plug.LoadResource, allow_blank: true
+
+  plug :set_metadata
+
+  defp set_metadata(conn, _params) do
+    if user = Guardian.Plug.current_resource(conn) do
+      Logger.metadata(user_id: user.id)
+    end
+
+    conn
+  end
 end


### PR DESCRIPTION
Because trying to find user errors in the logs without a `user_id` is _very_ hard.