### PR TITLE
give a better oauth account error during password login

### DIFF
--- a/lib/recognizer/accounts.ex
+++ b/lib/recognizer/accounts.ex
@@ -105,11 +105,14 @@ defmodule Recognizer.Accounts do
         where: u.email == ^email,
         preload: [notification_preference: n, roles: [], organization: o]
 
-    with %User{} = user <- Repo.one(query),
+    with %User{hashed_password: hash} = user when hash != "" <- Repo.one(query),
          true <- User.valid_password?(user, password),
          %User{two_factor_enabled: false} <- user do
       {:ok, user}
     else
+      %User{hashed_password: ""} = user ->
+        {:oauth, user}
+
       %User{two_factor_enabled: true} = user ->
         {:two_factor, user}
 

--- a/lib/recognizer_web/controllers/accounts/user_session_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_session_controller.ex
@@ -21,6 +21,11 @@ defmodule RecognizerWeb.Accounts.UserSessionController do
         |> put_session(:two_factor_sent, false)
         |> redirect(to: Routes.user_two_factor_path(conn, :new))
 
+      {:oauth, user} ->
+        conn
+        |> put_flash(:error, "It looks like this account was setup with third-party login")
+        |> render("new.html")
+
       nil ->
         conn
         |> put_flash(:error, "Invalid email or password")

--- a/test/recognizer_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_session_controller_test.exs
@@ -58,6 +58,19 @@ defmodule RecognizerWeb.Accounts.UserSessionControllerTest do
       assert redirected_to(conn) == Routes.user_two_factor_path(conn, :new)
     end
 
+    test "emits message when logging into an account with no password", %{conn: conn} do
+      user = insert(:user, password: "")
+
+      conn =
+        post(conn, Routes.user_session_path(conn, :create), %{
+          "user" => %{"email" => user.email, "password" => ""}
+        })
+
+      response = html_response(conn, 200)
+      assert response =~ "Log In</h2>"
+      assert response =~ "It looks like this account was setup with third-party login"
+    end
+
     test "emits error message with invalid credentials", %{conn: conn, user: user} do
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -27,6 +27,13 @@ defmodule Recognizer.AccountsFixtures do
     password = Map.get(attrs, :password, build(:password))
     password_changed_at = Map.get(attrs, :password_changed_at, NaiveDateTime.utc_now())
 
+    hashed_password =
+      if password == "" do
+        ""
+      else
+        Argon2.hash_pwd_salt(password)
+      end
+
     %Accounts.User{
       first_name: sequence(:first_name, &"first-name-#{&1}"),
       last_name: sequence(:last_name, &"last-name-#{&1}"),
@@ -36,7 +43,7 @@ defmodule Recognizer.AccountsFixtures do
       type: :individual,
       newsletter: false,
       password: password,
-      hashed_password: Argon2.hash_pwd_salt(password),
+      hashed_password: hashed_password,
       notification_preference: build(:notification_preference),
       password_changed_at: password_changed_at
     }


### PR DESCRIPTION
If a user with a connected oauth account and an empty string password tries to login with a password, they will get an error message "It looks like this account was setup with third-party login"