### PR TITLE
fix two factor session data when doing oauth loging

### DIFF
--- a/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_oauth_controller.ex
@@ -23,7 +23,8 @@ defmodule RecognizerWeb.Accounts.UserOAuthController do
 
       {:two_factor, user} ->
         conn
-        |> put_session(:current_user_id, user.id)
+        |> put_session(:two_factor_user_id, user.id)
+        |> put_session(:two_factor_sent, false)
         |> redirect(to: Routes.user_two_factor_path(conn, :new))
 
       {:error, %Ecto.Changeset{}} ->


### PR DESCRIPTION
Made to match how the two factor prompt works: https://github.com/system76/recognizer/blob/master/lib/recognizer_web/controllers/accounts/user_session_controller.ex#L18