### PR TITLE
Add third_party_login to user settings API

### DIFF
--- a/lib/recognizer/accounts.ex
+++ b/lib/recognizer/accounts.ex
@@ -60,10 +60,10 @@ defmodule Recognizer.Accounts do
 
     with %OAuth{user: user} <- Repo.one(query),
          %User{two_factor_enabled: false} <- user do
-      {:ok, user}
+      {:ok, %{user | third_party_login: true}}
     else
       %User{two_factor_enabled: true} = user ->
-        {:two_factor, user}
+        {:two_factor, %{user | third_party_login: true}}
 
       _ ->
         nil
@@ -137,10 +137,11 @@ defmodule Recognizer.Accounts do
       from u in User,
         join: n in assoc(u, :notification_preference),
         left_join: o in assoc(u, :organization),
+        left_join: uo in assoc(u, :oauths),
         where: u.id == ^id,
-        preload: [notification_preference: n, roles: [], organization: o]
+        preload: [oauths: uo, notification_preference: n, roles: [], organization: o]
 
-    Repo.one!(query)
+    query |> Repo.one!() |> User.load_virtuals()
   end
 
   ## User registration

--- a/lib/recognizer/accounts/oauth.ex
+++ b/lib/recognizer/accounts/oauth.ex
@@ -9,7 +9,7 @@ defmodule Recognizer.Accounts.OAuth do
   alias __MODULE__, as: OAuth
 
   schema "user_oauths" do
-    field :service, :string
+    field :service, Recognizer.OAuthService
     field :service_guid, :string
 
     belongs_to :user, User
@@ -19,7 +19,7 @@ defmodule Recognizer.Accounts.OAuth do
     oauth
     |> cast(attrs, [:service, :service_guid, :user_id])
     |> validate_required([:service, :service_guid])
-    |> validate_inclusion(:service, ["github", "google"])
+    |> EctoEnum.validate_enum(:service)
     |> assoc_constraint(:user)
   end
 end

--- a/lib/recognizer/ecto_enums.ex
+++ b/lib/recognizer/ecto_enums.ex
@@ -3,3 +3,4 @@ import EctoEnum
 defenum(Recognizer.TwoFactorPreference, ["app", "text", "voice"])
 
 defenum(Recognizer.UserType, ["individual", "business"])
+defenum(Recognizer.OAuthService, ["facebook", "github", "google"])

--- a/lib/recognizer_web/controllers/accounts/user_recovery_code_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_recovery_code_controller.ex
@@ -3,7 +3,6 @@ defmodule RecognizerWeb.Accounts.UserRecoveryCodeController do
   use RecognizerWeb, :controller
 
   alias Recognizer.Accounts
-  alias Recognizer.Notifications.Account
   alias RecognizerWeb.Authentication
 
   def new(conn, _params) do

--- a/lib/recognizer_web/views/accounts/api/user_settings_two_factor_view.ex
+++ b/lib/recognizer_web/views/accounts/api/user_settings_two_factor_view.ex
@@ -1,7 +1,6 @@
 defmodule RecognizerWeb.Accounts.Api.UserSettingsTwoFactorView do
   use RecognizerWeb, :view
 
-  alias Recognizer.Accounts.Role
   alias RecognizerWeb.Authentication
 
   def render("show.json", %{user: user} = params) do

--- a/lib/recognizer_web/views/accounts/api/user_settings_view.ex
+++ b/lib/recognizer_web/views/accounts/api/user_settings_view.ex
@@ -2,22 +2,22 @@ defmodule RecognizerWeb.Accounts.Api.UserSettingsView do
   use RecognizerWeb, :view
 
   alias Recognizer.Accounts.Role
-  alias RecognizerWeb.Authentication
 
   def render("show.json", %{user: user}) do
     %{
       user: %{
         id: user.id,
+        company_name: user.company_name,
+        email: user.email,
         first_name: user.first_name,
         last_name: user.last_name,
-        email: user.email,
-        phone_number: user.phone_number,
-        type: user.type,
-        company_name: user.company_name,
         newsletter: user.newsletter,
+        notification_preferences: render("notification_preferences.json", user),
+        phone_number: user.phone_number,
         staff: Role.admin?(user),
         two_factor_enabled: user.two_factor_enabled,
-        notification_preferences: render("notification_preferences.json", user)
+        type: user.type,
+        third_party_login: user.third_party_login
       }
     }
   end

--- a/priv/repo/migrations/20210215195133_add_user_oauths.exs
+++ b/priv/repo/migrations/20210215195133_add_user_oauths.exs
@@ -1,0 +1,12 @@
+defmodule Recognizer.Repo.Migrations.AddUserOauths do
+  use Ecto.Migration
+
+  def change do
+    create table(:user_oauths) do
+      add :service, :string
+      add :service_guid, :string
+
+      add :user_id, references(:users, type: "int(11) unsigned", on_delete: :nothing)
+    end
+  end
+end

--- a/priv/repo/migrations/20210215195133_add_user_oauths.exs
+++ b/priv/repo/migrations/20210215195133_add_user_oauths.exs
@@ -1,6 +1,14 @@
 defmodule Recognizer.Repo.Migrations.AddUserOauths do
   use Ecto.Migration
 
+  #  This migration is used for our existing database. It's commented out because
+  #  we will eventually move authentication to it's own database and this code
+  #  can be deleted.
+  #
+  #  def change do
+  #    #
+  #  end
+
   def change do
     create table(:user_oauths) do
       add :service, :"enum('facebook','github','google')"

--- a/priv/repo/migrations/20210215195133_add_user_oauths.exs
+++ b/priv/repo/migrations/20210215195133_add_user_oauths.exs
@@ -3,7 +3,7 @@ defmodule Recognizer.Repo.Migrations.AddUserOauths do
 
   def change do
     create table(:user_oauths) do
-      add :service, :string
+      add :service, :"enum('facebook','github','google')"
       add :service_guid, :string
 
       add :user_id, references(:users, type: "int(11) unsigned", on_delete: :nothing)

--- a/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
@@ -4,22 +4,33 @@ defmodule RecognizerWeb.Api.UserSettingsControllerTest do
   import Mox
   import Recognizer.AccountsFixtures
 
-  setup %{conn: conn} do
-    user = :user |> build() |> add_two_factor(:app) |> insert()
-
-    %{
-      conn: log_in_user(conn, user),
-      user: user
-    }
-  end
-
   describe "GET /api/settings" do
-    test "GET /api/settings", %{conn: conn, user: %{id: user_id}} do
+    test "two factor is reflected", %{conn: conn} do
+      %{id: user_id} = user = :user |> build() |> add_two_factor(:app) |> insert()
+      conn = conn |> log_in_user(user) |> get("/api/settings")
+
+      assert %{
+        "user" => %{
+          "id" => ^user_id,
+          "two_factor_enabled" => true
+        }
+      } = json_response(conn, 200)
+    end
+
+    test "shows third_party_login as true when logged in through oauth", context do
+      %{conn: conn, user: %{id: user_id}} = register_and_log_in_oauth_user(context)
       conn = get(conn, "/api/settings")
-      assert %{"user" => %{"id" => ^user_id, "two_factor_enabled" => true}} = json_response(conn, 200)
+
+      assert %{
+        "user" => %{
+          "id" => ^user_id,
+          "third_party_login" => true
+        }
+      } = json_response(conn, 200)
     end
   end
 
+  setup :register_and_log_in_user
   describe "PUT /api/settings" do
     setup :verify_on_exit!
 

--- a/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
@@ -10,11 +10,11 @@ defmodule RecognizerWeb.Api.UserSettingsControllerTest do
       conn = conn |> log_in_user(user) |> get("/api/settings")
 
       assert %{
-        "user" => %{
-          "id" => ^user_id,
-          "two_factor_enabled" => true
-        }
-      } = json_response(conn, 200)
+               "user" => %{
+                 "id" => ^user_id,
+                 "two_factor_enabled" => true
+               }
+             } = json_response(conn, 200)
     end
 
     test "shows third_party_login as true when logged in through oauth", context do
@@ -22,15 +22,16 @@ defmodule RecognizerWeb.Api.UserSettingsControllerTest do
       conn = get(conn, "/api/settings")
 
       assert %{
-        "user" => %{
-          "id" => ^user_id,
-          "third_party_login" => true
-        }
-      } = json_response(conn, 200)
+               "user" => %{
+                 "id" => ^user_id,
+                 "third_party_login" => true
+               }
+             } = json_response(conn, 200)
     end
   end
 
   setup :register_and_log_in_user
+
   describe "PUT /api/settings" do
     setup :verify_on_exit!
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -54,6 +54,13 @@ defmodule RecognizerWeb.ConnCase do
     %{conn: log_in_user(conn, user), user: user}
   end
 
+  def register_and_log_in_oauth_user(%{conn: conn}) do
+    user = Recognizer.AccountsFixtures.insert(:user)
+    oauth = Recognizer.AccountsFixtures.insert(:oauth, user: user)
+    user = Recognizer.Accounts.get_user!(user.id)
+    %{conn: log_in_user(conn, user), user: user, oauth: oauth}
+  end
+
   @doc """
   Logs the given `user` into the `conn`.
 

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -23,6 +23,13 @@ defmodule Recognizer.AccountsFixtures do
     }
   end
 
+  def oauth_factory(attrs) do
+    %Accounts.OAuth{
+      service: "github",
+      service_guid: sequence(:service_guid, &"oauth-guid-#{&1}")
+    } |> merge_attributes(attrs)
+  end
+
   def user_factory(attrs) do
     password = Map.get(attrs, :password, build(:password))
     password_changed_at = Map.get(attrs, :password_changed_at, NaiveDateTime.utc_now())

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -27,7 +27,8 @@ defmodule Recognizer.AccountsFixtures do
     %Accounts.OAuth{
       service: "github",
       service_guid: sequence(:service_guid, &"oauth-guid-#{&1}")
-    } |> merge_attributes(attrs)
+    }
+    |> merge_attributes(attrs)
   end
 
   def user_factory(attrs) do


### PR DESCRIPTION
Currently, Oauth users are presented with a password field when resetting their password or when adding 2-factor authentication. For Oauth users, this doesn't make sense since they cannot have both a Oauth-linked account and a user/pass account.  We need a way to tell them apart so that the app doesn't present them with the password field which doesn't do anything for them.

This adds a `third_party_login` boolean virtual field to the User struct which is hydrated when pulled from the database. This is set to true when the user has any oauth IDs saved in the database.

Refactored the tests a bit in `Api.UserSettingsControllerTest` to separate two-factor users, oauth users, and only set them up for the relevant tests.

This also creates the `oauth_users` table to catch up from our other system. This table already exists; we're only creating it here for tests.