### PR TITLE
fix double setting access token ttl config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -62,7 +62,7 @@ config :recognizer, ExOauth2Provider,
   default_scopes: ~w(profile:read),
   optional_scopes: ~w(profile:read profile:write),
   authorization_code_expires_in: 600,
-  access_token_expires_in: 7200,
+  access_token_expires_in: nil,
   use_refresh_token: true,
   revoke_refresh_token_on_use: true,
   force_ssl_in_redirect_uri: false

--- a/config/config.exs
+++ b/config/config.exs
@@ -62,7 +62,6 @@ config :recognizer, ExOauth2Provider,
   default_scopes: ~w(profile:read),
   optional_scopes: ~w(profile:read profile:write),
   authorization_code_expires_in: 600,
-  access_token_expires_in: nil,
   use_refresh_token: true,
   revoke_refresh_token_on_use: true,
   force_ssl_in_redirect_uri: false

--- a/lib/recognizer/guardian.ex
+++ b/lib/recognizer/guardian.ex
@@ -26,6 +26,7 @@ defmodule Recognizer.Guardian do
   end
 
   def encode_and_sign_access_token(access_token) do
+    expires_in = Keyword.get(access_token, :expires_in)
     user = Keyword.get(access_token, :resource_owner)
 
     scopes =
@@ -36,11 +37,14 @@ defmodule Recognizer.Guardian do
     {:ok, token, _claims} =
       encode_and_sign(user, %{scopes: scopes},
         token_type: "access",
-        ttl: {Keyword.get(access_token, :expires_in), :seconds}
+        ttl: ttl(expires_in)
       )
 
     token
   end
+
+  defp ttl(nil), do: nil
+  defp ttl(seconds), do: {seconds, :seconds}
 
   def after_encode_and_sign(resource, claims, token, _options) do
     with {:ok, _} <- Guardian.DB.after_encode_and_sign(resource, claims["typ"], claims, token) do

--- a/lib/recognizer/guardian.ex
+++ b/lib/recognizer/guardian.ex
@@ -26,7 +26,6 @@ defmodule Recognizer.Guardian do
   end
 
   def encode_and_sign_access_token(access_token) do
-    expires_in = Keyword.get(access_token, :expires_in)
     user = Keyword.get(access_token, :resource_owner)
 
     scopes =
@@ -34,17 +33,10 @@ defmodule Recognizer.Guardian do
       |> Keyword.get(:scopes, [])
       |> String.split(" ")
 
-    {:ok, token, _claims} =
-      encode_and_sign(user, %{scopes: scopes},
-        token_type: "access",
-        ttl: ttl(expires_in)
-      )
+    {:ok, token, _claims} = encode_and_sign(user, %{scopes: scopes}, token_type: "access")
 
     token
   end
-
-  defp ttl(nil), do: nil
-  defp ttl(seconds), do: {seconds, :seconds}
 
   def after_encode_and_sign(resource, claims, token, _options) do
     with {:ok, _} <- Guardian.DB.after_encode_and_sign(resource, claims["typ"], claims, token) do


### PR DESCRIPTION
This removes all of the ttl settings from the Oauth provider, and relies on Guardian to set those.

This should fix the short logout time for staff. Instead of the 2 hours the Oauth provider was set to, it should now be 24 hours like Guardian is set to.