### PR TITLE
Add warnings-as-errors check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: mix deps.get
 
+      - name: Compilation
+        run: mix compile --force --warnings-as-errors
+
       - name: Test
         run: mix test
         env:

--- a/lib/recognizer_web/controllers/accounts/user_session_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_session_controller.ex
@@ -21,7 +21,7 @@ defmodule RecognizerWeb.Accounts.UserSessionController do
         |> put_session(:two_factor_sent, false)
         |> redirect(to: Routes.user_two_factor_path(conn, :new))
 
-      {:oauth, user} ->
+      {:oauth, _user} ->
         conn
         |> put_flash(:error, "It looks like this account was setup with third-party login")
         |> render("new.html")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,9 @@
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 
+if System.get_env("CI") == "true" do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 Ecto.Adapters.SQL.Sandbox.mode(Recognizer.Repo, :manual)
 
 ExUnit.start()


### PR DESCRIPTION
Consider warnings as errors in our CI pipeline, for both real code and test code. This is to help keep unintentional bugs out of code.

One way we could avoid double-compilation is to include MIX_ENV=test, which should cover both dev and test env according to the current `elixirc_paths`. I left MIX_ENV out for now unless you have opinions. As-is, this adds about 5 seconds to the CI pipeline to compile.

Also adding the same flag but via `Code.put_compiler_option` for tests; thanks to [this tip](https://dashbit.co/blog/tests-with-warnings-as-errors). 