### PR TITLE
Allow passwordless accounts to be created

### DIFF
--- a/lib/recognizer/accounts.ex
+++ b/lib/recognizer/accounts.ex
@@ -162,9 +162,9 @@ defmodule Recognizer.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  def register_user(attrs) do
+  def register_user(attrs, opts \\ []) do
     %User{}
-    |> User.registration_changeset(attrs)
+    |> User.registration_changeset(attrs, opts)
     |> insert_user_and_notification_preferences()
     |> maybe_notify_new_user()
   end

--- a/lib/recognizer/accounts/user.ex
+++ b/lib/recognizer/accounts/user.ex
@@ -121,7 +121,7 @@ defmodule Recognizer.Accounts.User do
   end
 
   defp validate_password(changeset, opts) do
-    skip_password? = Keyword.get(opts, :skip_password, true)
+    skip_password? = Keyword.get(opts, :skip_password, false)
 
     if skip_password? do
       put_change(changeset, :password, nil)

--- a/lib/recognizer/accounts/user.ex
+++ b/lib/recognizer/accounts/user.ex
@@ -121,17 +121,23 @@ defmodule Recognizer.Accounts.User do
   end
 
   defp validate_password(changeset, opts) do
-    changeset
-    |> validate_required([:password])
-    |> validate_length(:password, min: 8, max: 80)
-    |> validate_format(:password, ~r/[0-9]/, message: "must contain a number")
-    |> validate_format(:password, ~r/[A-Z]/, message: "must contain an UPPERCASE letter")
-    |> validate_format(:password, ~r/[a-z]/, message: "must contain a lowercase letter")
-    |> validate_format(:password, ~r/[ \!\$\*\+\[\{\]\}\\\|\.\/\?,!@#%^&-=,.<>'";:]/,
-      message: "must contain a symbol or space"
-    )
-    |> validate_new_password(opts)
-    |> maybe_hash_password(opts)
+    skip_password? = Keyword.get(opts, :skip_password, true)
+
+    if skip_password? do
+      put_change(changeset, :password, nil)
+    else
+      changeset
+      |> validate_required([:password])
+      |> validate_length(:password, min: 8, max: 80)
+      |> validate_format(:password, ~r/[0-9]/, message: "must contain a number")
+      |> validate_format(:password, ~r/[A-Z]/, message: "must contain an UPPERCASE letter")
+      |> validate_format(:password, ~r/[a-z]/, message: "must contain a lowercase letter")
+      |> validate_format(:password, ~r/[ \!\$\*\+\[\{\]\}\\\|\.\/\?,!@#%^&-=,.<>'";:]/,
+        message: "must contain a symbol or space"
+      )
+      |> validate_new_password(opts)
+      |> maybe_hash_password(opts)
+    end
   end
 
   defp validate_company_name(changeset) do

--- a/lib/recognizer_web/controllers/accounts/api/user_registration_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/api/user_registration_controller.ex
@@ -1,0 +1,19 @@
+defmodule RecognizerWeb.Accounts.Api.UserRegistrationController do
+  use RecognizerWeb, :controller
+
+  alias Recognizer.Accounts
+  alias RecognizerWeb.ErrorView
+
+  def create(conn, %{"user" => user_params}) do
+    case Accounts.register_user(user_params, skip_password: true) do
+      {:ok, user} ->
+        render(conn, "show.json", user: user)
+
+      {:error, changeset} ->
+        conn
+        |> put_status(:bad_request)
+        |> put_view(ErrorView)
+        |> render("error.json", changeset: changeset)
+    end
+  end
+end

--- a/lib/recognizer_web/controllers/accounts/api/user_registration_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/api/user_registration_controller.ex
@@ -2,23 +2,26 @@ defmodule RecognizerWeb.Accounts.Api.UserRegistrationController do
   use RecognizerWeb, :controller
 
   alias Recognizer.Accounts.Role
-  alias Recognizer.{Accounts, Guardian}
-  alias RecognizerWeb.ErrorView
+  alias Recognizer.Accounts
+  alias RecognizerWeb.FallbackController
 
   def create(conn, %{"user" => user_params}) do
     with true <- staff_request?(conn),
          {:ok, user} <- Accounts.register_user(user_params, skip_password: true) do
-      render(conn, "show.json", user: user)
+      conn
+      |> put_status(201)
+      |> put_view(RecognizerWeb.Accounts.Api.UserSettingsView)
+      |> render("show.json", user: user)
     end
   end
 
-  def staff_request(conn) do
-    user = Guardian.current_resource(conn)
+  def staff_request?(conn) do
+    user = Guardian.Plug.current_resource(conn)
 
     if Role.admin?(user) do
       true
     else
-      {:invalid_token, "insufficient permissions"}
+      FallbackController.auth_error(conn, {:invalid_token, "insufficient permissions"}, :ignored)
     end
   end
 end

--- a/lib/recognizer_web/controllers/accounts/api/user_registration_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/api/user_registration_controller.ex
@@ -1,8 +1,11 @@
 defmodule RecognizerWeb.Accounts.Api.UserRegistrationController do
   use RecognizerWeb, :controller
 
-  alias Recognizer.Accounts
+  alias Recognizer.Accounts.Role
+  alias Recognizer.{Accounts, Guardian}
   alias RecognizerWeb.ErrorView
+
+  plug :staff_only
 
   def create(conn, %{"user" => user_params}) do
     case Accounts.register_user(user_params, skip_password: true) do
@@ -14,6 +17,18 @@ defmodule RecognizerWeb.Accounts.Api.UserRegistrationController do
         |> put_status(:bad_request)
         |> put_view(ErrorView)
         |> render("error.json", changeset: changeset)
+    end
+  end
+
+  def staff_only(conn, _opts) do
+    user = Guardian.current_resource(conn)
+
+    if Role.admin?(user) do
+      conn
+    else
+      conn
+      |> send_resp(401, "")
+      |> halt()
     end
   end
 end

--- a/lib/recognizer_web/controllers/fallback_controller.ex
+++ b/lib/recognizer_web/controllers/fallback_controller.ex
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.FallbackController do
   use RecognizerWeb, :controller
 
-  alias RecognizerWeb.Authentication
+  alias RecognizerWeb.{Authentication, ErrorView}
 
   @behaviour Guardian.Plug.ErrorHandler
 

--- a/lib/recognizer_web/controllers/fallback_controller.ex
+++ b/lib/recognizer_web/controllers/fallback_controller.ex
@@ -35,6 +35,13 @@ defmodule RecognizerWeb.FallbackController do
     respond(conn, :unauthorized, "401")
   end
 
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:bad_request)
+    |> put_view(ErrorView)
+    |> render("error.json", changeset: changeset)
+  end
+
   @impl true
   def call(conn, {:error, :unauthenticated}) do
     conn

--- a/lib/recognizer_web/router.ex
+++ b/lib/recognizer_web/router.ex
@@ -48,6 +48,7 @@ defmodule RecognizerWeb.Router do
     get "/settings/two-factor", UserSettingsTwoFactorController, :show
     put "/settings/two-factor", UserSettingsTwoFactorController, :update
     post "/settings/two-factor/send", UserSettingsTwoFactorController, :send
+    post "/create-account", UserRegistrationController, :create
   end
 
   scope "/", RecognizerWeb.OauthProvider, as: :oauth do

--- a/lib/recognizer_web/views/accounts/api/user_registration_view.ex
+++ b/lib/recognizer_web/views/accounts/api/user_registration_view.ex
@@ -1,0 +1,23 @@
+defmodule RecognizerWeb.Accounts.Api.UserRegistrationView do
+  use RecognizerWeb, :view
+
+  def render("show.json", %{user: user}) do
+    %{
+      user: %{
+        id: user.id,
+        company_name: user.company_name,
+        email: user.email,
+        first_name: user.first_name,
+        last_name: user.last_name,
+        newsletter: user.newsletter,
+        notification_preferences: render("notification_preferences.json", user),
+        phone_number: user.phone_number,
+        staff: Role.admin?(user),
+        two_factor_enabled: user.two_factor_enabled,
+        type: user.type,
+        third_party_login: user.third_party_login,
+        stripe_id: user.stripe_id
+      }
+    }
+  end
+end

--- a/lib/recognizer_web/views/accounts/api/user_registration_view.ex
+++ b/lib/recognizer_web/views/accounts/api/user_registration_view.ex
@@ -1,6 +1,8 @@
 defmodule RecognizerWeb.Accounts.Api.UserRegistrationView do
   use RecognizerWeb, :view
 
+  alias Recognizer.Accounts.Role
+
   def render("show.json", %{user: user}) do
     %{
       user: %{

--- a/test/recognizer/accounts_test.exs
+++ b/test/recognizer/accounts_test.exs
@@ -2,7 +2,7 @@ defmodule Recognizer.AccountsTest do
   use Recognizer.DataCase
 
   import Mox
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   alias Recognizer.Accounts
   alias Recognizer.Accounts.User

--- a/test/recognizer_web/authentication_test.exs
+++ b/test/recognizer_web/authentication_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.AuthenticationTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   alias RecognizerWeb.Authentication
 

--- a/test/recognizer_web/controllers/accounts/api/user_registration_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/api/user_registration_controller_test.exs
@@ -1,0 +1,37 @@
+defmodule RecognizerWeb.Api.UserRegistrationControllerTest do
+  use RecognizerWeb.ConnCase
+
+  setup :register_and_log_in_admin
+
+  describe "POST /api/create-account" do
+    test "POST /api/create-account is limited to staff only", %{conn: conn} do
+      conn =
+        post(conn, "/api/create-account", %{
+          "user" => %{
+            "email" => "test@example.com",
+            "first_name" => "Test",
+            "last_name" => "User"
+          }
+        })
+
+      assert %{"user" => _} = json_response(conn, 201)
+    end
+
+    test "POST /api/create-account fails for regular users", %{conn: conn} do
+      conn =
+        %{conn: conn}
+        |> register_and_log_in_user()
+        |> Map.get(:conn)
+        |> Plug.Conn.put_req_header("accept", "application/json")
+        |> post("/api/create-account", %{
+          "user" => %{
+            "email" => "test@example.com",
+            "first_name" => "Test",
+            "last_name" => "User"
+          }
+        })
+
+      assert json_response(conn, 401)
+    end
+  end
+end

--- a/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
@@ -2,7 +2,7 @@ defmodule RecognizerWeb.Api.UserSettingsControllerTest do
   use RecognizerWeb.ConnCase
 
   import Mox
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   describe "GET /api/settings" do
     test "two factor is reflected", %{conn: conn} do

--- a/test/recognizer_web/controllers/accounts/api/user_settings_two_factor_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/api/user_settings_two_factor_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.Api.UserSettingsTwoFactorControllerTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   setup %{conn: conn} do
     user = :user |> insert()

--- a/test/recognizer_web/controllers/accounts/prompt/change_password_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/prompt/change_password_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.Accounts.Prompt.ChangePasswordControllerTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   alias Recognizer.Accounts
 

--- a/test/recognizer_web/controllers/accounts/prompt/two_factor_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/prompt/two_factor_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.Accounts.Prompt.TwoFactorControllerTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   setup %{conn: conn} do
     user =

--- a/test/recognizer_web/controllers/accounts/user_recovery_code_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_recovery_code_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.Accounts.UserRecoveryCodeControllerTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   setup %{conn: conn} do
     user = :user |> build() |> add_two_factor() |> insert()

--- a/test/recognizer_web/controllers/accounts/user_registration_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_registration_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.Accounts.UserRegistrationControllerTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   describe "GET /users/register" do
     test "renders registration page", %{conn: conn} do

--- a/test/recognizer_web/controllers/accounts/user_reset_password_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_reset_password_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.Accounts.UserResetPasswordControllerTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   alias Recognizer.Accounts
 

--- a/test/recognizer_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_session_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.Accounts.UserSessionControllerTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   setup do
     two_factor_user = :user |> build() |> add_two_factor() |> insert()

--- a/test/recognizer_web/controllers/accounts/user_settings_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_settings_controller_test.exs
@@ -2,7 +2,7 @@ defmodule RecognizerWeb.Accounts.UserSettingsControllerTest do
   use RecognizerWeb.ConnCase
 
   import Mox
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   alias Recognizer.Accounts
 

--- a/test/recognizer_web/controllers/accounts/user_two_factor_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_two_factor_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule RecognizerWeb.Accounts.UserTwoFactorControllerTest do
   use RecognizerWeb.ConnCase
 
-  import Recognizer.AccountsFixtures
+  import Recognizer.AccountFactory
 
   alias RecognizerWeb.Authentication
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -49,14 +49,20 @@ defmodule RecognizerWeb.ConnCase do
   It stores an updated connection and a registered user in the
   test context.
   """
+  def register_and_log_in_admin(%{conn: conn}) do
+    user = Recognizer.AccountFactory.insert(:user)
+    Recognizer.AccountFactory.insert(:role, user_id: user.id, role_id: 2)
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
   def register_and_log_in_user(%{conn: conn}) do
-    user = Recognizer.AccountsFixtures.insert(:user)
+    user = Recognizer.AccountFactory.insert(:user)
     %{conn: log_in_user(conn, user), user: user}
   end
 
   def register_and_log_in_oauth_user(%{conn: conn}) do
-    user = Recognizer.AccountsFixtures.insert(:user)
-    oauth = Recognizer.AccountsFixtures.insert(:oauth, user: user)
+    user = Recognizer.AccountFactory.insert(:user)
+    oauth = Recognizer.AccountFactory.insert(:oauth, user: user)
     user = Recognizer.Accounts.get_user!(user.id)
     %{conn: log_in_user(conn, user), user: user, oauth: oauth}
   end

--- a/test/support/factories/account_factory.ex
+++ b/test/support/factories/account_factory.ex
@@ -1,4 +1,4 @@
-defmodule Recognizer.AccountsFixtures do
+defmodule Recognizer.AccountFactory do
   @moduledoc """
   This module defines test helpers for creating entities via the
   `Recognizer.Accounts` context.
@@ -29,6 +29,10 @@ defmodule Recognizer.AccountsFixtures do
       service_guid: sequence(:service_guid, &"oauth-guid-#{&1}")
     }
     |> merge_attributes(attrs)
+  end
+
+  def role_factory(attrs) do
+    struct(Accounts.Role, attrs)
   end
 
   def user_factory(attrs) do


### PR DESCRIPTION
Existing processes within the company rely on staff being able to create
a user account with no password, later set with password reset. This
accounts will only be created via the API and UI in the administrative
portal.