### PR TITLE
Add `roles` claim and "staff" the role for admins

### DIFF
--- a/lib/recognizer/guardian.ex
+++ b/lib/recognizer/guardian.ex
@@ -28,12 +28,14 @@ defmodule Recognizer.Guardian do
   def encode_and_sign_access_token(access_token) do
     user = Keyword.get(access_token, :resource_owner)
 
+    roles = if Accounts.Role.admin?(user), do: ["staff"], else: []
+
     scopes =
       access_token
       |> Keyword.get(:scopes, [])
       |> String.split(" ")
 
-    {:ok, token, _claims} = encode_and_sign(user, %{scopes: scopes}, token_type: "access")
+    {:ok, token, _claims} = encode_and_sign(user, %{roles: roles, scopes: scopes}, token_type: "access")
 
     token
   end

--- a/test/recognizer/accounts_test.exs
+++ b/test/recognizer/accounts_test.exs
@@ -52,7 +52,9 @@ defmodule Recognizer.AccountsTest do
 
     test "returns the user with the given id" do
       %{id: id} = user = insert(:user)
-      assert %User{id: ^id} = Accounts.get_user!(user.id)
+      insert(:role, user_id: id, role_id: 2)
+
+      assert %User{id: ^id, roles: [%{role_id: 2}]} = Accounts.get_user!(user.id)
     end
   end
 


### PR DESCRIPTION
Right now we have no means of identifying when a JWT belongs to staff or customer without making a follow-up API call to get their settings which contains the flag.

This adds a new claim, `roles`, and for staff the role "staff". **This is not a complete implementation of the existing legacy roles.** We had originally decided with Recognizer to avoid going down that rabbit hole and settled on going no deeper than the join table on this association. I'd like to avoid having to do all of that just for this simple addition. Later I'd be happy to revisit the entirety of roles and bringing support for them (and improving them to boot) to Recognizer.