### PR TITLE
Remove rabbitmq config unless in production

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -95,17 +95,4 @@ config :spandex_ecto, SpandexEcto.EctoLogger,
 config :spandex_phoenix, tracer: Recognizer.Tracer
 config :spandex, :decorators, tracer: Recognizer.Tracer
 
-config :amqp,
-  connections: [
-    rabbitmq_conn: [
-      username: "",
-      password: "",
-      host: "",
-      port: 5672
-    ]
-  ],
-  channels: [
-    events: [connection: :rabbitmq_conn]
-  ]
-
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
By including this config in `config.exs` it requires us to have a rabbitmq connection going in dev and test envs. Removing this allows us to run recognizer without rabbitmq. Needed to fix issues with testing.