### PR TITLE
Setup lager before logger in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Recognizer.MixProject do
   def application do
     [
       mod: {Recognizer.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:lager, :logger, :runtime_tools]
     ]
   end
 


### PR DESCRIPTION
Fixes

```sh
calling logger:remove_handler(default) failed: :error {:badmatch, {:error, {:not_found, :default}}}
```
In the logs as per https://github.com/pma/amqp#lager-conflicts-with-elixir-logger