### PR TITLE
Email 2fa fix - Avoid internal server error

### DIFF
--- a/lib/recognizer_web/controllers/accounts/user_two_factor_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_two_factor_controller.ex
@@ -36,32 +36,39 @@ defmodule RecognizerWeb.Accounts.UserTwoFactorController do
     current_user_id = get_session(conn, :two_factor_user_id)
     current_user = Accounts.get_user!(current_user_id)
     current_time = System.system_time(:second)
-    %{notification_preference: %{two_factor: two_factor_method}} = Accounts.load_notification_preferences(current_user)
+    current_user = Accounts.load_notification_preferences(current_user)
+    case current_user do
+      {:error, _} ->
+        conn.redirect(to: Routes.user_session_path(conn, :new))
+      {:error, _} ->
+        conn.redirect(to: Routes.user_session_path(conn, :new))
+      {:ok, current_user} ->
+        %{notification_preference: %{two_factor: two_factor_method}} = current_user
+        conn =
+          if get_session(conn, :two_factor_issue_time) == nil do
+            conn
+            |> put_session(:two_factor_issue_time, current_time)
+          else
+            conn
+          end
 
-    conn =
-      if get_session(conn, :two_factor_issue_time) == nil do
-        conn
-        |> put_session(:two_factor_issue_time, current_time)
-      else
-        conn
-      end
+        two_factor_sent = get_session(conn, :two_factor_sent)
 
-    two_factor_sent = get_session(conn, :two_factor_sent)
+        conn =
+          if two_factor_sent == false do
+            conn
+            |> maybe_send_two_factor_notification(current_user, two_factor_method)
 
-    conn =
-      if two_factor_sent == false do
-        conn
-        |> maybe_send_two_factor_notification(current_user, two_factor_method)
+            conn
+            |> put_session(:two_factor_sent, true)
+            |> put_session(:two_factor_issue_time, current_time)
+          else
+            conn
+          end
 
         conn
-        |> put_session(:two_factor_sent, true)
-        |> put_session(:two_factor_issue_time, current_time)
-      else
-        conn
-      end
-
-    conn
-    |> render("new.html", two_factor_method: two_factor_method)
+        |> render("new.html", two_factor_method: two_factor_method)
+    end
   end
 
   @doc """

--- a/lib/recognizer_web/controllers/accounts/user_two_factor_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_two_factor_controller.ex
@@ -37,6 +37,7 @@ defmodule RecognizerWeb.Accounts.UserTwoFactorController do
     current_user = Accounts.get_user!(current_user_id)
     current_time = System.system_time(:second)
     current_user = Accounts.load_notification_preferences(current_user)
+
     case current_user do
       %{notification_preference: %{two_factor: two_factor_method}} ->
         conn =
@@ -63,9 +64,9 @@ defmodule RecognizerWeb.Accounts.UserTwoFactorController do
 
         conn
         |> render("new.html", two_factor_method: two_factor_method)
+
       _ ->
         conn.redirect(to: Routes.user_session_path(conn, :new))
-
     end
   end
 

--- a/lib/recognizer_web/controllers/accounts/user_two_factor_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_two_factor_controller.ex
@@ -38,12 +38,7 @@ defmodule RecognizerWeb.Accounts.UserTwoFactorController do
     current_time = System.system_time(:second)
     current_user = Accounts.load_notification_preferences(current_user)
     case current_user do
-      {:error, _} ->
-        conn.redirect(to: Routes.user_session_path(conn, :new))
-      {:ok, nil} ->
-        conn.redirect(to: Routes.user_session_path(conn, :new))
-      {:ok, current_user} ->
-        %{notification_preference: %{two_factor: two_factor_method}} = current_user
+      %{notification_preference: %{two_factor: two_factor_method}} ->
         conn =
           if get_session(conn, :two_factor_issue_time) == nil do
             conn
@@ -68,6 +63,9 @@ defmodule RecognizerWeb.Accounts.UserTwoFactorController do
 
         conn
         |> render("new.html", two_factor_method: two_factor_method)
+      _ ->
+        conn.redirect(to: Routes.user_session_path(conn, :new))
+
     end
   end
 

--- a/lib/recognizer_web/controllers/accounts/user_two_factor_controller.ex
+++ b/lib/recognizer_web/controllers/accounts/user_two_factor_controller.ex
@@ -40,7 +40,7 @@ defmodule RecognizerWeb.Accounts.UserTwoFactorController do
     case current_user do
       {:error, _} ->
         conn.redirect(to: Routes.user_session_path(conn, :new))
-      {:error, _} ->
+      {:ok, nil} ->
         conn.redirect(to: Routes.user_session_path(conn, :new))
       {:ok, current_user} ->
         %{notification_preference: %{two_factor: two_factor_method}} = current_user

--- a/lib/recognizer_web/router.ex
+++ b/lib/recognizer_web/router.ex
@@ -140,6 +140,6 @@ defmodule RecognizerWeb.Router do
     get "/settings/two-factor/review", UserSettingsController, :review
     get "/settings/two-factor", UserSettingsController, :two_factor_init
     post "/settings/two-factor", UserSettingsController, :two_factor_confirm
-    get "/setting/two-factor/resend", UserSettingsController, :resend
+    get "/settings/two-factor/resend", UserSettingsController, :resend
   end
 end


### PR DESCRIPTION
Avoid Internal server errors.
Redirect when GET request without valid sessions.