### PR TITLE
Fix name filtering to match other mail services names

### DIFF
--- a/lib/recognizer/accounts/user.ex
+++ b/lib/recognizer/accounts/user.ex
@@ -133,11 +133,13 @@ defmodule Recognizer.Accounts.User do
 
   defp validate_names(changeset) do
     changeset
-    |> validate_format(:first_name, ~r/^[A-Za-zÀ-ÖØ-öø-ÿ'’.\- ]{1,100}$/,
-      message: "Please enter a valid name using letters, spaces, and basic punctuation like apostrophes (’), periods (.) and hyphens (-)"
+    |> validate_format(:first_name, ~r/^[A-Za-zÀ-ÖØ-öø-ÿ0-9'.\- ]{1,80}$/,
+      message:
+        "Please enter a valid name using letters, spaces, and basic punctuation"
     )
-    |> validate_format(:last_name, ~r/^[A-Za-zÀ-ÖØ-öø-ÿ'’.\- ]{1,100}$/,
-      message: "Please enter a valid name using letters, spaces, and basic punctuation like apostrophes (’), periods (.) and hyphens (-)"
+    |> validate_format(:last_name, ~r/^[A-Za-zÀ-ÖØ-öø-ÿ0-9'.\- ]{1,80}$/,
+      message:
+        "Please enter a valid name using letters, spaces, and basic punctuation"
     )
     |> validate_length(:first_name, max: 80)
     |> validate_length(:last_name, max: 80)
@@ -166,7 +168,7 @@ defmodule Recognizer.Accounts.User do
       |> validate_format(:password, ~r/[0-9]/, message: "must contain a number")
       |> validate_format(:password, ~r/[A-Z]/, message: "must contain an UPPERCASE letter")
       |> validate_format(:password, ~r/[a-z]/, message: "must contain a lowercase letter")
-      |> validate_format(:password, ~r/[ \!\$\*\+\[\{\]\}\\\|\.\/\?,!@#%^&-=,.<>'";:]/,
+      |> validate_format(:password, ~r/[ !$*+\[\]{}\\|.\/?@#%^&=<>'";:-]/,
         message: "must contain a symbol or space"
       )
       |> validate_new_password(opts)

--- a/lib/recognizer/accounts/user.ex
+++ b/lib/recognizer/accounts/user.ex
@@ -134,12 +134,10 @@ defmodule Recognizer.Accounts.User do
   defp validate_names(changeset) do
     changeset
     |> validate_format(:first_name, ~r/^[A-Za-zÀ-ÖØ-öø-ÿ0-9'.\- ]{1,80}$/,
-      message:
-        "Please enter a valid name using letters, spaces, and basic punctuation"
+      message: "Please enter a valid name using letters, spaces, and basic punctuation"
     )
     |> validate_format(:last_name, ~r/^[A-Za-zÀ-ÖØ-öø-ÿ0-9'.\- ]{1,80}$/,
-      message:
-        "Please enter a valid name using letters, spaces, and basic punctuation"
+      message: "Please enter a valid name using letters, spaces, and basic punctuation"
     )
     |> validate_length(:first_name, max: 80)
     |> validate_length(:last_name, max: 80)
@@ -168,9 +166,7 @@ defmodule Recognizer.Accounts.User do
       |> validate_format(:password, ~r/[0-9]/, message: "must contain a number")
       |> validate_format(:password, ~r/[A-Z]/, message: "must contain an UPPERCASE letter")
       |> validate_format(:password, ~r/[a-z]/, message: "must contain a lowercase letter")
-      |> validate_format(:password, ~r/[ !$*+\[\]{}\\|.\/?@#%^&=<>'";:-]/,
-        message: "must contain a symbol or space"
-      )
+      |> validate_format(:password, ~r/[ !$*+\[\]{}\\|.\/?@#%^&=<>'";:-]/, message: "must contain a symbol or space")
       |> validate_new_password(opts)
       |> maybe_hash_password(opts)
     end

--- a/lib/recognizer/accounts/user.ex
+++ b/lib/recognizer/accounts/user.ex
@@ -133,8 +133,12 @@ defmodule Recognizer.Accounts.User do
 
   defp validate_names(changeset) do
     changeset
-    |> validate_format(:first_name, ~r/^[\w\s\d\,\'\-\_\.]+$/u, message: "must not contain special characters")
-    |> validate_format(:last_name, ~r/^[\w\s\d\,\'\-\_\.]+$/u, message: "must not contain special characters")
+    |> validate_format(:first_name, ~r/^[A-Za-zÀ-ÖØ-öø-ÿ'’.\- ]{1,100}$/,
+      message: "Please enter a valid name using letters, spaces, and basic punctuation like apostrophes (’), periods (.) and hyphens (-)"
+    )
+    |> validate_format(:last_name, ~r/^[A-Za-zÀ-ÖØ-öø-ÿ'’.\- ]{1,100}$/,
+      message: "Please enter a valid name using letters, spaces, and basic punctuation like apostrophes (’), periods (.) and hyphens (-)"
+    )
     |> validate_length(:first_name, max: 80)
     |> validate_length(:last_name, max: 80)
   end

--- a/lib/recognizer_web/templates/accounts/user_registration/new.html.eex
+++ b/lib/recognizer_web/templates/accounts/user_registration/new.html.eex
@@ -121,7 +121,7 @@
     <div class="field mt-5">
       <div class="control">
         <%= label class: "label" do %>
-          <%= checkbox f, :newsletter %>
+          <%= checkbox f, :newsletter, checked: true %>
           Subscribe to our newsletter
         <% end %>
       </div>

--- a/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
@@ -45,12 +45,17 @@ defmodule RecognizerWeb.Api.UserSettingsControllerTest do
 
     test "don't allow special characters in the first name", %{conn: conn} do
       conn = put(conn, "/api/settings", %{"action" => "update", "user" => %{"first_name" => "http://example.com"}})
-      assert %{"errors" => %{"first_name" => ["Please enter a valid name using letters, spaces, and basic punctuation"]}} = json_response(conn, 400)
+
+      assert %{
+               "errors" => %{"first_name" => ["Please enter a valid name using letters, spaces, and basic punctuation"]}
+             } = json_response(conn, 400)
     end
 
     test "don't allow special characters in the last name", %{conn: conn} do
       conn = put(conn, "/api/settings", %{"action" => "update", "user" => %{"last_name" => "http://example.com"}})
-      assert %{"errors" => %{"last_name" => ["Please enter a valid name using letters, spaces, and basic punctuation"]}} = json_response(conn, 400)
+
+      assert %{"errors" => %{"last_name" => ["Please enter a valid name using letters, spaces, and basic punctuation"]}} =
+               json_response(conn, 400)
     end
 
     test "PUT /api/settings with `update_password` action", %{conn: conn, user: user} do

--- a/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/api/user_settings_controller_test.exs
@@ -45,12 +45,12 @@ defmodule RecognizerWeb.Api.UserSettingsControllerTest do
 
     test "don't allow special characters in the first name", %{conn: conn} do
       conn = put(conn, "/api/settings", %{"action" => "update", "user" => %{"first_name" => "http://example.com"}})
-      assert %{"errors" => %{"first_name" => ["must not contain special characters"]}} = json_response(conn, 400)
+      assert %{"errors" => %{"first_name" => ["Please enter a valid name using letters, spaces, and basic punctuation"]}} = json_response(conn, 400)
     end
 
     test "don't allow special characters in the last name", %{conn: conn} do
       conn = put(conn, "/api/settings", %{"action" => "update", "user" => %{"last_name" => "http://example.com"}})
-      assert %{"errors" => %{"last_name" => ["must not contain special characters"]}} = json_response(conn, 400)
+      assert %{"errors" => %{"last_name" => ["Please enter a valid name using letters, spaces, and basic punctuation"]}} = json_response(conn, 400)
     end
 
     test "PUT /api/settings with `update_password` action", %{conn: conn, user: user} do

--- a/test/recognizer_web/controllers/accounts/user_registration_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_registration_controller_test.exs
@@ -104,7 +104,7 @@ defmodule RecognizerWeb.Accounts.UserRegistrationControllerTest do
       assert response =~ "Create Account</h2>"
       assert response =~ "must have the @ sign, no spaces and a top level domain"
       assert response =~ "must contain a number"
-      assert response =~ "must not contain special characters"
+      assert response =~ "Please enter a valid name using letters, spaces, and basic punctuation"
     end
 
     @tag :capture_log

--- a/test/recognizer_web/controllers/accounts/user_settings_controller_test.exs
+++ b/test/recognizer_web/controllers/accounts/user_settings_controller_test.exs
@@ -109,7 +109,7 @@ defmodule RecognizerWeb.Accounts.UserSettingsControllerTest do
 
       response = html_response(conn, 200)
       assert response =~ "Update Profile</h2>"
-      assert response =~ "must not contain special characters"
+      assert response =~ "Please enter a valid name using letters, spaces, and basic punctuation"
     end
 
     test "does not update last name on invalid data", %{conn: conn} do
@@ -121,7 +121,7 @@ defmodule RecognizerWeb.Accounts.UserSettingsControllerTest do
 
       response = html_response(conn, 200)
       assert response =~ "Update Profile</h2>"
-      assert response =~ "must not contain special characters"
+      assert response =~ "Please enter a valid name using letters, spaces, and basic punctuation"
     end
 
     test "update two-factor allows app setup without a phone number", %{conn: conn, user: user} do


### PR DESCRIPTION
- To improve deliverability, we've adjusted our validation rules to allow a wider range of characters in user names. - We observed that some email services like Outlook may filter out emails if the sender's display name differs from the recipient's registered name. 

- Additionally, we've updated the default setting for newsletter subscription to True during registration.

- name can accept numbers on test purpose - We are using "name-05" cases on testing 
So message not included support numbers on name fields officially.