### PR TITLE
Revert OAuth user login routes from /auth back to /oauth

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -69,7 +69,7 @@ config :guardian, Guardian.DB,
   sweep_interval: 60
 
 config :ueberauth, Ueberauth,
-  base_path: "/auth",
+  base_path: "/oauth",
   providers: [
     github: {Ueberauth.Strategy.Github, [default_scope: "user:email", send_redirect_uri: false]},
     google: {Ueberauth.Strategy.Google, [default_scope: "email profile"]}

--- a/lib/recognizer_web/router.ex
+++ b/lib/recognizer_web/router.ex
@@ -89,8 +89,8 @@ defmodule RecognizerWeb.Router do
     get "/forgot-password/:token", UserResetPasswordController, :edit
     put "/forgot-password/:token", UserResetPasswordController, :update
 
-    get "/auth/:provider", UserOAuthController, :request, as: :user_oauth
-    get "/auth/:provider/callback", UserOAuthController, :callback, as: :user_oauth
+    get "/oauth/:provider", UserOAuthController, :request, as: :user_oauth
+    get "/oauth/:provider/callback", UserOAuthController, :callback, as: :user_oauth
 
     get "/two-factor", UserTwoFactorController, :new
     post "/two-factor", UserTwoFactorController, :create


### PR DESCRIPTION
This reverts the route changes from the previous commit to fix Google OAuth redirect_uri_mismatch error.

The real fix for Blazer OAuth flow is in authentication.ex's login_redirect function, which now detects OAuth Provider flow and preserves it instead of redirecting to REDIRECT_URL.

Changes:
- Revert base_path from "/auth" to "/oauth" in Ueberauth config
- Revert routes from /auth/:provider to /oauth/:provider

Fixes: Google OAuth login redirect_uri_mismatch error